### PR TITLE
Add Kyle Kloster's authorship

### DIFF
--- a/content/metadata.yaml
+++ b/content/metadata.yaml
@@ -35,6 +35,16 @@ author_info:
       - Department of Systems Pharmacology and Translational Therapeutics, University of Pennsylvania, Philadelphia, Pennsylvania, United States of America
     funders: Pfizer Worldwide Research and Development; the Gordon and Betty Moore Foundation (GBMF4552)
   -
+    github: kkloste
+    name: Kyle Kloster
+    initials: KAK
+    orcid: 0000-0001-5678-7197
+    twitter: kylekloster
+    email: kyle.kloster@gmail.com
+    affiliations:
+      - Department of Computer Science, North Carolina State University, Raleigh, North Carolina, United States of America
+    funders: the Gordon and Betty Moore Foundation (GBMF4560)
+  -
     github: cgreene
     name: Casey S. Greene
     initials: CSG


### PR DESCRIPTION
I am no longer working at NC State, but all of my contributions were completed while at NC State,
so I believe listing my affiliation as "NC State" is appropriate in this case.