### PR TITLE
Add placeholders for figures

### DIFF
--- a/content/02.body.md
+++ b/content/02.body.md
@@ -2,6 +2,8 @@
 
 ### Node degree
 
+![Degree figure](){#fig:degree width="100%"}
+
 ### Edge prediction
 
 ### Feature-degree correlation
@@ -26,6 +28,9 @@
 
 ## Results
 
+![Discrimination figure](){#fig:discrimination width="100%"}
+
+![Calibration figure](){#fig:calibration width="100%"}
 
 ## Discussion
 


### PR DESCRIPTION
An issue I notice is that multiple subsections need to reference the same figures, but references are broken by the fact that figures are only included in the PRs for the subsections in which they appear. This adds simple placeholders for the figures I currently anticipate in the manuscript body.