### PR TITLE
Proofreads and addition to edge prior appendix

### DIFF
--- a/content/90.back-matter.md
+++ b/content/90.back-matter.md
@@ -41,18 +41,18 @@ With "no edge" represented as $[1, 0]^T$ and "edge" represented as $[0, 1]^T$, t
 
 The stationary distribution of this system should correspond to the distribution when the number of swaps goes to infinity.
 It can be found by computing the eigenvectors of the system, as we know that the stationary distribution vector, $\mathbf{v}$ satisfies $P^T \mathbf{v} = \mathbf{v}$.
-The normalized eigenvector $\mathbf{v}$ is given by
+The eigenvector $\mathbf{v}$, normalized to sum to 1 as a probability vector, is given by
 
 \begin{align*}
-    \mathbf{v} = \frac{1}{r/q + 1} \begin{bmatrix}
-        r/q \\
-        1
+    \mathbf{v} = \frac{1}{r + q} \begin{bmatrix}
+        r \\
+        q
     \end{bmatrix}
 \end{align*}
 
 The asymptotic edge probability is therefore
 
-$$\frac{1}{r/q + 1}.$$
+$$\frac{q}{r + q}.$$
 
 Since node pairs are being treated as independent, the probability of an edge being created in one successful iteration, given that the edge does not currently exist, is the ratio of the number of edge choices involving nodes $i$ and $j$ to the total number of possible swaps, $S$.
 Let $d(u_i)$ represent the degree of source node $i$ and $d(v_j)$ represent the degree of target node $j$.
@@ -75,6 +75,7 @@ We found that the following modified form (introduced in Methods) affords a supe
     P_{i,j} = \frac{d(u_i) d(v_j)}{\sqrt{(d(u_i) d(v_j))^2 + (m - d(u_i) - d(v_j) + 1)^2}}
 \end{equation}
 
+Interestingly, this expression can be derived by normalizing the eigenvector $\mathbf{v}$ to be a unit vector in the 2-norm instead of the 1-norm; that is, we use the value $q / \sqrt{r^2 + q^2}$ instead of $q/(r+q)$.
 Because the modified form of the approximation offers a much superior fit to the data, we chose to include only the modified version in the Python package released, and we used the modified form throughout our analysis.
 
 ### Networks used for comparison {#networks}


### PR DESCRIPTION
* I think this way of writing the stationary distribution is much cleaner, and makes clearer that it is a probability vector
* Given that the approximate probability expression we use is simply the same eigenvector entry when normalized in the 2-norm instead of the 1-norm, I feel like this is important to note. That can't be a coincidence, and making this observation could help someone eventually find the right way of deriving the approximate probability expression we use.