### PR TITLE
Add caption, bump table number

### DIFF
--- a/content/90.back-matter.md
+++ b/content/90.back-matter.md
@@ -262,6 +262,9 @@ Because the modified form of the approximation offers a much superior fit to the
     <td class="tg-buh4">29177</td>
   </tr>
 </table>
+Table:
+Networks used for the comparison.
+Abbreviations are protein-protein interaction (PPI) and transcription-factor-target-gene (TF-TG). {#tbl:xswap tag="S2"}
 
 ### Edge prediction features
 
@@ -280,7 +283,7 @@ All definitions that follow are the score between nodes $u$ and $v$.
 | Random walk with restart score | $c \bigg[ \bigg( \mathbb{I} - (1-c) \mathbf{A}\bigg)^{-1} \mathbf{y}_u \bigg]_v$ | [@doi:10.1145/1014052.1014135;@raw:laplacian] |
 | Inference score | $\frac{|A(u) \cap D(v)|}{|A(u)|} + \frac{|D(u) \cap D(v)|}{|D(u)|}$ | [@doi:10.5821/dissertation-2117-95691] |
 
-Table: Edge prediction features. {#tbl:edge-prediction tag="S2"}
+Table: Edge prediction features. {#tbl:edge-prediction tag="S3"}
 
 ## References {.page_break_before}
 


### PR DESCRIPTION
Adding a caption to the intermediate table means we will need to bump S2 -> S3. S2 is currently referenced in the main text twice.

Edit: I just changed those two references in the main text to S3.